### PR TITLE
Fixed #10 - Component trigger many internet calls

### DIFF
--- a/custom_components/netgear_wax/client.py
+++ b/custom_components/netgear_wax/client.py
@@ -1,7 +1,7 @@
 """Netgear API Client."""
 import abc
 from dataclasses import dataclass
-from typing import List, Dict
+from typing import List, Dict, Optional
 
 
 @dataclass(unsafe_hash=True)
@@ -49,7 +49,7 @@ class NetgearClient(abc.ABC):
         pass
 
     @abc.abstractmethod
-    async def async_get_state(self) -> DeviceState:
+    async def async_get_state(self, check_firmware: Optional[bool] = False) -> DeviceState:
         pass
 
     @abc.abstractmethod

--- a/custom_components/netgear_wax/const.py
+++ b/custom_components/netgear_wax/const.py
@@ -39,3 +39,32 @@ If you have any issues with this you need to open an issue here:
 {ISSUE_URL}
 -------------------------------------------------------------------
 """
+
+STATE_REQUEST_DATA = {
+    "system": {
+        "monitor": {
+            "productId": "",
+            "totalNumberOfDevices": "",
+            "sysSerialNumber": "",
+            "ethernetMacAddress": "",
+            "sysVersion": "",
+            "FiveGhzSupport": {},
+            "stats": {
+                "lan": {
+                    "traffic": "",
+                },
+                "wlan0": {
+                    "traffic": "",
+                    "channelUtil": "",
+                },
+                "wlan1": {
+                    "traffic": "",
+                    "channelUtil": "",
+                }
+            },
+        },
+        "basicSettings": {
+            "apName": "",
+        },
+    }
+}


### PR DESCRIPTION
- Moved logic (`__init__.py`) of whether to trigger firmware update before checking state, so state will be able to use the latest update
- Wrap the check whether it's time to check firmware update as variable and pass it to the `async_get_state` of both `client.py` and `client_wax.py`
- Moved the state request data to `consts.py` and removed sections `FwUpdate` and monitor parameter of `internetConnectivityStatus`
- Add IF statement to check if the internet connectivity was not checked since it was loaded or over the last hour, in case it is time to check, add `internetConnectivityStatus` to monitors
- Add IF statement to check if the firmware update function ran, in case it did, will add the `FwUpdate` section

Tested in local environment, working great.
